### PR TITLE
Fix #3 Add Test unit

### DIFF
--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue1574Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue1574Test.java
@@ -1,0 +1,30 @@
+package com.github.javaparser.symbolsolver;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.comments.Comment;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue1574Test {
+    private static final String FILE_PATH = "src/test/resources/issue1574/Comment.java";
+    @Test
+    void getAllCommentBeforePackageDeclaration() throws Exception{
+        CompilationUnit cu = StaticJavaParser.parse(new File(FILE_PATH));
+        List<Comment> comments = cu.getAllContainedComments();
+        assertEquals(3,comments.size());
+
+    }
+    @Test
+    void geOrphanComments() throws Exception{
+        CompilationUnit cu = StaticJavaParser.parse(new File(FILE_PATH));
+        List<Comment> comments = cu.getOrphanComments();
+        //The 2 first should be orphan comment while the third will be associated to the package
+        assertEquals(2,comments.size());
+
+    }
+}

--- a/javaparser-symbol-solver-testing/src/test/resources/issue1574/Comment.java
+++ b/javaparser-symbol-solver-testing/src/test/resources/issue1574/Comment.java
@@ -1,0 +1,9 @@
+//Comment1
+//Comment2
+//Comment3
+package aPackage;
+public class comment{
+    public void main(String args[]){
+        System.out.println("HelloWorld");
+    }
+}


### PR DESCRIPTION
Add an issue class `Issue1574Test`  in `test.com.github.javaparser.symbolsolver` and the ressources in `resources.issue1574`.
In `Issue1574Test` I added one test on `getAllContainedComments` and one on
`getOrphanComments()` that both fail with difference of one comment.

